### PR TITLE
Feature/multi intervention exclusion

### DIFF
--- a/site_persistence_file.json
+++ b/site_persistence_file.json
@@ -279,20 +279,59 @@
       "resourceType": "Intervention"
     }, 
     {
-      "description": "Wisercare [strategy_1: (user NOT IN sexual_recovery)] AND [strategy_2: <a nested combined strategy>: ((user NOT IN list of clinics (including UW)) AND (user IN list of clinics (including UCSF))] AND [strategy_3: (user has NOT started TX)] AND [strategy_4: (user has PCaLocalized)]", 
+      "description": "Wisercare [strategy_1: <a nested combined strategy>: (user NOT IN (sexual_recovery, care_plan, community_of_wellness)] AND [strategy_2: <a nested combined strategy>: ((user NOT IN list of clinics (including UW)) AND (user IN list of clinics (including UCSF))] AND [strategy_3: (user has NOT started TX)] AND [strategy_4: (user has PCaLocalized)]", 
       "function_details": {
         "function": "combine_strategies", 
         "kwargs": [
           {
             "name": "strategy_1", 
-            "value": "allow_if_not_in_intervention"
+            "value": "combine_strategies"
           }, 
           {
             "name": "strategy_1_kwargs", 
             "value": [
               {
-                "name": "intervention_name", 
-                "value": "sexual_recovery"
+                "name": "combinator", 
+                "value": "all"
+              }, 
+              {
+                "name": "strategy_1", 
+                "value": "allow_if_not_in_intervention"
+              }, 
+              {
+                "name": "strategy_1_kwargs", 
+                "value": [
+                  {
+                    "name": "intervention_name", 
+                    "value": "sexual_recovery"
+                  }
+                ]
+              }, 
+              {
+                "name": "strategy_2", 
+                "value": "allow_if_not_in_intervention"
+              }, 
+              {
+                "name": "strategy_2_kwargs", 
+                "value": [
+                  {
+                    "name": "intervention_name", 
+                    "value": "care_plan"
+                  }
+                ]
+              }, 
+              {
+                "name": "strategy_3", 
+                "value": "allow_if_not_in_intervention"
+              }, 
+              {
+                "name": "strategy_3_kwargs", 
+                "value": [
+                  {
+                    "name": "intervention_name", 
+                    "value": "community_of_wellness"
+                  }
+                ]
               }
             ]
           }, 

--- a/site_persistence_file.json
+++ b/site_persistence_file.json
@@ -173,7 +173,7 @@
       "resourceType": "Intervention"
     }, 
     {
-      "description": "P3P [strategy_1: (user NOT IN sexual_recovery)] AND [strategy_2 <a nested combined strategy>: ((user NOT IN list of clinics (including UCSF)) OR (user IN list of clinics including UCSF and UW))] AND [strategy_3: (user has NOT started TX)] AND [strategy_4: (user has PCaLocalized)]", 
+      "description": "P3P [strategy_1: <a nested combined strategy>: (user NOT IN (sexual_recovery, care_plan, community_of_wellness)] AND [strategy_2 <a nested combined strategy>: ((user NOT IN list of clinics (including UCSF)) OR (user IN list of clinics including UCSF and UW))] AND [strategy_3: (user has NOT started TX)] AND [strategy_4: (user has PCaLocalized)]", 
       "function_details": {
         "function": "combine_strategies", 
         "kwargs": [
@@ -185,8 +185,47 @@
             "name": "strategy_1_kwargs", 
             "value": [
               {
-                "name": "intervention_name", 
-                "value": "sexual_recovery"
+                "name": "combinator", 
+                "value": "all"
+              }, 
+              {
+                "name": "strategy_1", 
+                "value": "allow_if_not_in_intervention"
+              }, 
+              {
+                "name": "strategy_1_kwargs", 
+                "value": [
+                  {
+                    "name": "intervention_name", 
+                    "value": "sexual_recovery"
+                  }
+                ]
+              }, 
+              {
+                "name": "strategy_2", 
+                "value": "allow_if_not_in_intervention"
+              }, 
+              {
+                "name": "strategy_2_kwargs", 
+                "value": [
+                  {
+                    "name": "intervention_name", 
+                    "value": "care_plan"
+                  }
+                ]
+              }, 
+              {
+                "name": "strategy_3", 
+                "value": "allow_if_not_in_intervention"
+              }, 
+              {
+                "name": "strategy_3_kwargs", 
+                "value": [
+                  {
+                    "name": "intervention_name", 
+                    "value": "community_of_wellness"
+                  }
+                ]
               }
             ]
           }, 

--- a/site_persistence_file.json
+++ b/site_persistence_file.json
@@ -179,7 +179,7 @@
         "kwargs": [
           {
             "name": "strategy_1", 
-            "value": "allow_if_not_in_intervention"
+            "value": "combine_strategies"
           }, 
           {
             "name": "strategy_1_kwargs", 


### PR DESCRIPTION
This adds additional intervention exclusions for both decision support interventions (P3P & Wisercare), namely, that neither will show if the user is active with any of {sexual_recovery, care_plan, community_of_wellness}.  Last details for issue #134454589.