### PR TITLE
added config variables for consent and orgs

### DIFF
--- a/site_persistence_file.json
+++ b/site_persistence_file.json
@@ -606,6 +606,8 @@
         "GIL = True\n", 
         "SHOW_WELCOME = True\n",
         "SHOW_PROFILE_MACROS = ['race', 'ethnicity', 'consent', 'clinical_questions', 'intervention_reports']\n", 
+        "CONSENT_EDIT_PERMISSIBLE_ROLES=['patient', 'admin']\n",
+        "CONSENT_WITH_TOP_LEVEL_ORG=True\n",
         "\n", 
         "# Assessment Engine configuration\n", 
         "INSTRUMENTS = [\n", 


### PR DESCRIPTION
- added config variable to specify consents be with top level organizations

- address this story:  https://www.pivotaltracker.com/n/projects/1225464where roles allowed to edit consents are different between Eproms and Truenth
In Truenth,  a patient is allowed to edit consents (as opposed to Eproms)