### PR TITLE
add 'procedures' string to show profile macros list

### DIFF
--- a/site_persistence_file.json
+++ b/site_persistence_file.json
@@ -678,7 +678,7 @@
         "PORTAL_STYLESHEET = 'css/portal.css'\n", 
         "GIL = True\n", 
         "SHOW_WELCOME = True\n",
-        "SHOW_PROFILE_MACROS = ['race', 'ethnicity', 'consent', 'clinical_questions', 'intervention_reports']\n", 
+        "SHOW_PROFILE_MACROS = ['race', 'ethnicity', 'consent', 'clinical_questions', 'intervention_reports', 'procedures']\n", 
         "CONSENT_EDIT_PERMISSIBLE_ROLES=['patient', 'admin']\n",
         "CONSENT_WITH_TOP_LEVEL_ORG=True\n",
         "\n", 


### PR DESCRIPTION
- adding procedures as one of the show_profile_macro list items to allow view/hide of procedures section in profile