### PR TITLE
This is a change to bring back the UW orgs to production (instead of …

### DIFF
--- a/site_persistence_file.json
+++ b/site_persistence_file.json
@@ -208,9 +208,6 @@
                   {
                     "name": "org_list", 
                     "value": [
-                      "WiserCare Clinical Institution",
-                      "WiserCare Clinic A", 
-                      "WiserCare Clinic B" 
                     ]
                   }
                 ]
@@ -228,10 +225,7 @@
                       "UW Medicine (University of Washington)",
                       "Urology Clinic at UWMC",
                       "SCCA Urology Clinic",
-                      "Urology Clinic at Harborview",
-                      "WiserCare Clinical Institution",
-                      "WiserCare Clinic A", 
-                      "WiserCare Clinic B" 
+                      "Urology Clinic at Harborview"
                     ]
                   }
                 ]
@@ -376,9 +370,10 @@
                   {
                     "name": "org_list", 
                     "value": [
-                      "P3P Clinical Institution",
-                      "P3P Clinic A",
-                      "P3P Clinic B"
+                      "UW Medicine (University of Washington)",
+                      "Urology Clinic at UWMC",
+                      "SCCA Urology Clinic",
+                      "Urology Clinic at Harborview"
                     ]
                   }
                 ]
@@ -393,9 +388,6 @@
                   {
                     "name": "org_list", 
                     "value": [
-                      "WiserCare Clinical Institution",
-                      "WiserCare Clinic A", 
-                      "WiserCare Clinic B" 
                     ]
                   },
                   {

--- a/site_persistence_file.json
+++ b/site_persistence_file.json
@@ -22,10 +22,10 @@
           "assigner": null, 
           "system": "http://us.truenth.org/identity-codes/shortcut-alias", 
           "use": "usual", 
-          "value": "p3pinstitution"
+          "value": "uwmc"
         }
       ], 
-      "name": "P3P Clinical Institution", 
+      "name": "UW Medicine (University of Washington)", 
       "resourceType": "Organization", 
       "telecom": []
     }, 
@@ -37,16 +37,10 @@
           "assigner": null, 
           "system": "http://us.truenth.org/identity-codes/shortcut-alias", 
           "use": "usual", 
-          "value": "p3pclinica"
-        },
-        {
-          "assigner": null, 
-          "system": "http://us.truenth.org/identity-codes/shortcut-alias", 
-          "use": "usual", 
-          "value": "p3pclinca"
+          "value": "uwurology"
         }
       ], 
-      "name": "P3P Clinic A", 
+      "name": "Urology Clinic at UWMC", 
       "partOf": {
         "reference": "api/organization/101"
       }, 
@@ -61,10 +55,10 @@
           "assigner": null, 
           "system": "http://us.truenth.org/identity-codes/shortcut-alias", 
           "use": "usual", 
-          "value": "p3pclinicb"
+          "value": "sccaurology"
         }
       ], 
-      "name": "P3P Clinic B", 
+      "name": "SCCA Urology Clinic", 
       "partOf": {
         "reference": "api/organization/101"
       }, 
@@ -79,69 +73,12 @@
           "assigner": null, 
           "system": "http://us.truenth.org/identity-codes/shortcut-alias", 
           "use": "usual", 
-          "value": "p3pclinicc"
+          "value": "harborviewurology"
         }
       ], 
-      "name": "P3P Clinic C", 
+      "name": "Urology Clinic at Harborview", 
       "partOf": {
         "reference": "api/organization/101"
-      }, 
-      "resourceType": "Organization", 
-      "telecom": []
-    }, 
-    {
-      "address": [], 
-      "id": 201, 
-      "identifier": [
-        {
-          "assigner": null, 
-          "system": "http://hl7.org/fhir/sid/us-npi", 
-          "use": "official", 
-          "value": "1164512851"
-        }, 
-        {
-          "assigner": null, 
-          "system": "http://us.truenth.org/identity-codes/shortcut-alias", 
-          "use": "usual", 
-          "value": "wcinstitution"
-        }
-      ], 
-      "name": "WiserCare Clinical Institution", 
-      "resourceType": "Organization", 
-      "telecom": []
-    }, 
-    {
-      "address": [], 
-      "id": 202, 
-      "identifier": [
-        {
-          "assigner": null, 
-          "system": "http://us.truenth.org/identity-codes/shortcut-alias", 
-          "use": "usual", 
-          "value": "wcclinica"
-        }
-      ], 
-      "name": "WiserCare Clinic A", 
-      "partOf": {
-        "reference": "api/organization/201"
-      }, 
-      "resourceType": "Organization", 
-      "telecom": []
-    }, 
-    {
-      "address": [], 
-      "id": 203, 
-      "identifier": [
-        {
-          "assigner": null, 
-          "system": "http://us.truenth.org/identity-codes/shortcut-alias", 
-          "use": "usual", 
-          "value": "wcclinicb"
-        }
-      ], 
-      "name": "WiserCare Clinic B", 
-      "partOf": {
-        "reference": "api/organization/201"
       }, 
       "resourceType": "Organization", 
       "telecom": []
@@ -288,9 +225,10 @@
                   {
                     "name": "org_list", 
                     "value": [
-                      "P3P Clinical Institution",
-                      "P3P Clinic A",
-                      "P3P Clinic B",
+                      "UW Medicine (University of Washington)",
+                      "Urology Clinic at UWMC",
+                      "SCCA Urology Clinic",
+                      "Urology Clinic at Harborview",
                       "WiserCare Clinical Institution",
                       "WiserCare Clinic A", 
                       "WiserCare Clinic B" 

--- a/site_persistence_file.json
+++ b/site_persistence_file.json
@@ -570,7 +570,7 @@
     }, 
     {
       "custom_text": "{config[LR_ORIGIN]}/c/portal/truenth/asset/detailed?groupId={config[LR_GROUP]}&version=latest&uuid=a3b73a90-d7b2-f6a0-f4b9-3b3d716ee6ca",
-      "name": "P3P Clinical Institution organization consent URL", 
+      "name": "UW Medicine (University of Washington) organization consent URL", 
       "resourceType": "AppText"
     }, 
     {


### PR DESCRIPTION
…eg "P3P Clinic A"), and to remove the "WiserCare Clinical Institution", formerly "UCSF Medical Center". I'm wary of the impact on access strategies, since they now reference orgs that no longer exist.