### PR TITLE
add gender as one item for show macros list variable

### DIFF
--- a/site_persistence_file.json
+++ b/site_persistence_file.json
@@ -684,7 +684,7 @@
         "PORTAL_STYLESHEET = 'css/portal.css'\n", 
         "GIL = True\n", 
         "SHOW_WELCOME = True\n",
-        "SHOW_PROFILE_MACROS = ['race', 'ethnicity', 'consent', 'clinical_questions', 'intervention_reports', 'procedures']\n", 
+        "SHOW_PROFILE_MACROS = ['race', 'ethnicity', 'consent', 'clinical_questions', 'intervention_reports', 'procedures', 'gender']\n", 
         "CONSENT_EDIT_PERMISSIBLE_ROLES=['patient', 'admin']\n",
         "CONSENT_WITH_TOP_LEVEL_ORG=True\n",
         "\n", 


### PR DESCRIPTION
address this story:  https://www.pivotaltracker.com/story/show/141256785

- allow gender section in profile to be visible only in Truenth

I think this PR may create conflict with this PR, which I didn't realize wasn't merged: https://github.com/uwcirg/TrueNTH-USA-site-config/pull/24

I will resolve conflict if any occur.
