### PR TITLE
Add invite email url AppText entry to persistence file

### DIFF
--- a/site_persistence_file.json
+++ b/site_persistence_file.json
@@ -1225,6 +1225,11 @@
       "resourceType": "AppText"
     }, 
     {
+      "custom_text": "{config[LR_ORIGIN]}/c/portal/truenth/asset/mail?version=latest&uuid=32a6713e-5051-8079-0ed3-0a7eeb607c03",
+      "name": "profileSendEmail invite email",
+      "resourceType": "AppText"
+    },
+    {
       "custom_text": "TrueNTH Reminder", 
       "name": "profileSendEmail reminder email_subject", 
       "resourceType": "AppText"


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/150369091

* added new AppText entry for 'profileSendEmail invite email', which provides the URL for the corresponding LR content

Tied directly to https://github.com/uwcirg/true_nth_usa_portal/pull/1268